### PR TITLE
Check if VM is already powered off before halting

### DIFF
--- a/lib/vagrant-multiprovider-snap/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-multiprovider-snap/providers/virtualbox/driver/base.rb
@@ -11,8 +11,7 @@ module VagrantPlugins
                 end
 
                 def snapshot_rollback(bootmode)
-                    info = execute("showvminfo", @uuid, "--machinereadable")
-                    if ! info =~ /^VMState="poweroff"/ # don't try to power off if we're already off
+                    if read_state != :poweroff # don't try to power off if we're already off
                         halt
                         sleep 2 # race condition on locked VMs otherwise?
                     end


### PR DESCRIPTION
Before this commit, rolling back a snapshot from a VM in a poweroff
state results in the below error:

Stderr: VBoxManage: error: Invalid machine state: PoweredOff (must be
Running, Paused or Stuck)

This commit adds a check to skip the halting step if the machine is
already off.
