### PR TITLE
Expand skip-halt logic to include aborted state

### DIFF
--- a/lib/vagrant-multiprovider-snap/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-multiprovider-snap/providers/virtualbox/driver/base.rb
@@ -11,7 +11,8 @@ module VagrantPlugins
                 end
 
                 def snapshot_rollback(bootmode)
-                    if read_state != :poweroff # don't try to power off if we're already off
+                    # don't try to power off if we're already off
+                    unless [:poweroff, :aborted].include?(read_state)
                         halt
                         sleep 2 # race condition on locked VMs otherwise?
                     end


### PR DESCRIPTION
We already don't bother trying to halt a machine in the poweroff state. This commit goes further and says that if a machine is aborted, we aren't going to try to halt it. This is necessary to successfully do a `vagrant snap rollback` against an aborted machine.
