### PR TITLE
rollback with correct bootmode

### DIFF
--- a/lib/vagrant-multiprovider-snap/providers/vmware_fusion/action/snapshot_rollback.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_fusion/action/snapshot_rollback.rb
@@ -16,7 +16,7 @@ module HashiCorp
 
                     # Snapshot rollback involves powering off and on the VM
                     #  so we need to find the gui state
-                    boot_mode = env[:machine].provider_config.gui ? "gui" : "headless"
+                    boot_mode = env[:machine].provider_config.gui ? "gui" : "nogui"
 
                     env[:machine].provider.driver.snapshot_rollback(boot_mode)
 

--- a/lib/vagrant-multiprovider-snap/providers/vmware_fusion/driver/base.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_fusion/driver/base.rb
@@ -12,7 +12,7 @@ module HashiCorp
 
                 def snapshot_rollback(bootmode)
                    vmrun("revertToSnapshot", "#{vmx_path}", snapshot_list.last)
-                   start
+                   vmrun("start", "#{vmx_path}", bootmode)
                 end
 
                 def snapshot_list

--- a/lib/vagrant-multiprovider-snap/providers/vmware_workstation/action/snapshot_rollback.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_workstation/action/snapshot_rollback.rb
@@ -16,7 +16,7 @@ module HashiCorp
 
                     # Snapshot rollback involves powering off and on the VM
                     #  so we need to find the gui state
-                    boot_mode = env[:machine].provider_config.gui ? "gui" : "headless"
+                    boot_mode = env[:machine].provider_config.gui ? "gui" : "nogui"
 
                     env[:machine].provider.driver.snapshot_rollback(boot_mode)
 

--- a/lib/vagrant-multiprovider-snap/providers/vmware_workstation/driver/base.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_workstation/driver/base.rb
@@ -12,7 +12,7 @@ module HashiCorp
 
                 def snapshot_rollback(bootmode)
                    vmrun("revertToSnapshot", "#{vmx_path}", snapshot_list.last)
-                   start
+                   vmrun("start", "#{vmx_path}", bootmode)
                 end
 
                 def snapshot_list


### PR DESCRIPTION
I found your plugin useful as I started using the vagrant-vmware-fusion plugin as I want to do some tests with Mac VM's on my Mac.

But I have a problem with VM that are running in gui mode.

I have tested it with a Mac VM and an Ubuntu desktop VM ( "box-cutter/ubuntu1404-desktop" from vagrantcloud ) and both end up in a headless mode after rolling back to the last snapshot.

What I did is this

``` bash
vagrant init box-cutter/ubuntu1404-desktop
vagrant up
vagrant snapshot take
VAGRANT_LOG=debug vagrant snapshot rollback
```

On `vagrant up` the gui appears, taking the snapshot take some time. Then the `vagrant snapshot rollback` shuts down the VM and starts it in headless mode.

Here is the part of the vagrant debug log. Your plugin reads that the boot_mode should be gui, but the vmrun start command has a parameter "nogui" at the end.

```
==> default: Rolling back to previous snapshot
 INFO interface: info: boot_mode = gui
 INFO interface: info: ==> default: boot_mode = gui
==> default: boot_mode = gui
 INFO subprocess: Starting process: ["/Applications/VMware Fusion.app/Contents/Library/vmrun", "listSnapshots", "/Users/stefan/code/tst-vagrant-multiprovider-snap/.vagrant/machines/default/vmware_fusion/db80af19-79c5-495e-8646-e1bd6eeb5b23/ubuntu1404-desktop.vmx"]
DEBUG subprocess: Command not in installer, not touching env vars.
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: Total snapshots: 1
vagrant-snap-1405885722
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO subprocess: Starting process: ["/Applications/VMware Fusion.app/Contents/Library/vmrun", "revertToSnapshot", "/Users/stefan/code/tst-vagrant-multiprovider-snap/.vagrant/machines/default/vmware_fusion/db80af19-79c5-495e-8646-e1bd6eeb5b23/ubuntu1404-desktop.vmx", "vagrant-snap-1405885722"]
DEBUG subprocess: Command not in installer, not touching env vars.
DEBUG subprocess: Selecting on IO
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 31999
DEBUG subprocess: Exit status: 0
 INFO subprocess: Starting process: ["/Applications/VMware Fusion.app/Contents/Library/vmrun", "start", "/Users/stefan/code/tst-vagrant-multiprovider-snap/.vagrant/machines/default/vmware_fusion/db80af19-79c5-495e-8646-e1bd6eeb5b23/ubuntu1404-desktop.vmx", "nogui"]
DEBUG subprocess: Command not in installer, not touching env vars.
```

Perhaps the problem lies in `lib/vagrant-multiprovider-snap/
[lib/vagrant-multiprovider-snap/providers/vmware_fusion/driver/base.rb line 15](https://github.com/scalefactory/vagrant-multiprovider-snap/blob/master/lib/vagrant-multiprovider-snap/providers/vmware_fusion/driver/base.rb#L15) as the parameter bootmode is not used:

``` ruby
                def snapshot_rollback(bootmode)
                   vmrun("revertToSnapshot", "#{vmx_path}", snapshot_list.last)
                   start
                end
```

My first thought was, if you have any hint to fix it.
I find this plugin very helpful and want to use this for gui VM's as well.

But then I compared the additional vmrun call and the start call in the debug log and fought, let's do a own vmrun  call with the start command.

And that's my PR that fixes this issue. I had to change the `headless` string to `nogui`as vmrun shows only `gui` and `nogui` as values.

My setup is
- Mac OS X 10.9.3 with
- Vagrant 1.6.3
- vagrant-vmware-fusion (2.4.1)
- VMware Fusion 6.0.4
