### PR TITLE
Support for named snapshots and arbitrary rollback

### DIFF
--- a/lib/vagrant-multiprovider-snap/command/rollback.rb
+++ b/lib/vagrant-multiprovider-snap/command/rollback.rb
@@ -10,10 +10,17 @@ module VagrantSnap
             def execute
 
                 options = {}
+                options[:snap_name] = nil
 
                 opts = OptionParser.new do |o|
-                    o.banner    = "Usage: vagrant snap rollback [vm-name]"
+
+                    o.banner    = "Usage: vagrant snap rollback [vm-name] [--name=<snapname>]"
                     o.separator ""
+
+                    o.on("--name SNAPNAME", "Roll back to the named snapshot (defaults to last taken)") do |n|
+                        options[:snap_name] = n
+                    end
+
                 end
 
                 argv = parse_options(opts)
@@ -21,7 +28,7 @@ module VagrantSnap
 
                 with_target_vms(argv) do |vm|
 
-                    vm.action(:snapshot_rollback)
+                    vm.action(:snapshot_rollback, :snap_name => options[:snap_name])
 
                 end
 

--- a/lib/vagrant-multiprovider-snap/command/take.rb
+++ b/lib/vagrant-multiprovider-snap/command/take.rb
@@ -10,10 +10,17 @@ module VagrantSnap
             def execute
 
                 options = {}
+                options[:snap_name] = nil
 
                 opts = OptionParser.new do |o|
-                    o.banner    = "Usage: vagrant snap take [vm-name]"
+
+                    o.banner    = "Usage: vagrant snap take [vm-name] [--name=<snapname>]"
                     o.separator ""
+
+                    o.on("--name SNAPNAME", "Use the given name for this snapshot") do |n|
+                        options[:snap_name] = n
+                    end
+
                 end
 
                 argv = parse_options(opts)
@@ -21,7 +28,7 @@ module VagrantSnap
 
                 with_target_vms(argv) do |vm|
 
-                    vm.action(:snapshot_take)
+                    vm.action(:snapshot_take, :snap_name => options[:snap_name])
 
                 end
 

--- a/lib/vagrant-multiprovider-snap/providers/virtualbox/action/snapshot_rollback.rb
+++ b/lib/vagrant-multiprovider-snap/providers/virtualbox/action/snapshot_rollback.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
                     #  so we need to find the gui state
                     boot_mode = env[:machine].provider_config.gui ? "gui" : "headless"
 
-                    env[:machine].provider.driver.snapshot_rollback(boot_mode)
+                    env[:machine].provider.driver.snapshot_rollback(boot_mode,env[:snap_name])
 
                     @app.call(env)
 

--- a/lib/vagrant-multiprovider-snap/providers/virtualbox/action/snapshot_take.rb
+++ b/lib/vagrant-multiprovider-snap/providers/virtualbox/action/snapshot_take.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
                 def call(env)
 
                     env[:ui].info I18n.t("vagrant_snap.actions.vm.snapshot_take.taking")
-                    env[:machine].provider.driver.snapshot_take
+                    env[:machine].provider.driver.snapshot_take(env[:snap_name])
 
                     @app.call(env)
 

--- a/lib/vagrant-multiprovider-snap/providers/virtualbox/driver/base.rb
+++ b/lib/vagrant-multiprovider-snap/providers/virtualbox/driver/base.rb
@@ -6,17 +6,17 @@ module VagrantPlugins
 
             class Base
 
-                def snapshot_take
-                    execute("snapshot", @uuid, "take", "vagrant-snap-#{Time.now.to_i}", "--pause")
+                def snapshot_take(name)
+                    execute("snapshot", @uuid, "take", name || "vagrant-snap-#{Time.now.to_i}", "--pause")
                 end
 
-                def snapshot_rollback(bootmode)
+                def snapshot_rollback(bootmode, name)
                     # don't try to power off if we're already off
                     unless [:poweroff, :aborted].include?(read_state)
                         halt
                         sleep 2 # race condition on locked VMs otherwise?
                     end
-                    execute("snapshot",  @uuid, "restore", snapshot_list.last)
+                    execute("snapshot",  @uuid, "restore", name || snapshot_list.last)
                     start(bootmode)
                 end
 
@@ -24,11 +24,11 @@ module VagrantPlugins
                     info = execute("showvminfo", @uuid, "--machinereadable")
                     snapshots = []
                     info.split("\n").each do |line|
-                        if line =~ /^SnapshotName[^=]*="(vagrant-snap-.+?)"$/
+                        if line =~ /^SnapshotName[^=]*="(.+?)"$/
                             snapshots << $1.to_s
                         end
                     end
-                    snapshots.sort
+                    snapshots
                 end
 
                 def has_snapshot?

--- a/lib/vagrant-multiprovider-snap/providers/vmware_fusion/action/snapshot_rollback.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_fusion/action/snapshot_rollback.rb
@@ -18,7 +18,7 @@ module HashiCorp
                     #  so we need to find the gui state
                     boot_mode = env[:machine].provider_config.gui ? "gui" : "headless"
 
-                    env[:machine].provider.driver.snapshot_rollback(boot_mode)
+                    env[:machine].provider.driver.snapshot_rollback(boot_mode, env[:snap_name])
 
                     @app.call(env)
 

--- a/lib/vagrant-multiprovider-snap/providers/vmware_fusion/action/snapshot_take.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_fusion/action/snapshot_take.rb
@@ -13,7 +13,7 @@ module HashiCorp
                 def call(env)
 
                     env[:ui].info I18n.t("vagrant_snap.actions.vm.snapshot_take.taking")
-                    env[:machine].provider.driver.snapshot_take
+                    env[:machine].provider.driver.snapshot_take(env[:snap_name])
 
                     @app.call(env)
 

--- a/lib/vagrant-multiprovider-snap/providers/vmware_fusion/driver/base.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_fusion/driver/base.rb
@@ -6,23 +6,23 @@ module HashiCorp
 
             class Fusion
 
-                def snapshot_take
-                    vmrun("snapshot", "#{vmx_path}", "vagrant-snap-#{Time.now.to_i}")
+                def snapshot_take(name)
+                    vmrun("snapshot", "#{vmx_path}", name || "vagrant-snap-#{Time.now.to_i}")
                 end
 
-                def snapshot_rollback(bootmode)
-                   vmrun("revertToSnapshot", "#{vmx_path}", snapshot_list.last)
-                   start
+                def snapshot_rollback(bootmode, name)
+                    vmrun("revertToSnapshot", "#{vmx_path}", name || snapshot_list.last)
+                    start
                 end
 
                 def snapshot_list
                     snapshots = []
                     vmrun("listSnapshots", "#{vmx_path}").stdout.split("\n").each do |line|
-                        if line =~ /^vagrant-snap-/
+                        if line !~ /Total snapshot/
                             snapshots << line
                         end
                     end
-                    snapshots.sort
+                    snapshots
                 end
 
                 def has_snapshot?

--- a/lib/vagrant-multiprovider-snap/providers/vmware_workstation/action/snapshot_rollback.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_workstation/action/snapshot_rollback.rb
@@ -18,7 +18,7 @@ module HashiCorp
                     #  so we need to find the gui state
                     boot_mode = env[:machine].provider_config.gui ? "gui" : "headless"
 
-                    env[:machine].provider.driver.snapshot_rollback(boot_mode)
+                    env[:machine].provider.driver.snapshot_rollback(boot_mode,env[:snap_name])
 
                     @app.call(env)
 

--- a/lib/vagrant-multiprovider-snap/providers/vmware_workstation/action/snapshot_take.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_workstation/action/snapshot_take.rb
@@ -13,7 +13,7 @@ module HashiCorp
                 def call(env)
 
                     env[:ui].info I18n.t("vagrant_snap.actions.vm.snapshot_take.taking")
-                    env[:machine].provider.driver.snapshot_take
+                    env[:machine].provider.driver.snapshot_take(env[:snap_name])
 
                     @app.call(env)
 

--- a/lib/vagrant-multiprovider-snap/providers/vmware_workstation/driver/base.rb
+++ b/lib/vagrant-multiprovider-snap/providers/vmware_workstation/driver/base.rb
@@ -6,23 +6,23 @@ module HashiCorp
 
             class Base
 
-                def snapshot_take
-                    vmrun("snapshot", "#{vmx_path}", "vagrant-snap-#{Time.now.to_i}")
+                def snapshot_take(name)
+                    vmrun("snapshot", "#{vmx_path}", name || "vagrant-snap-#{Time.now.to_i}")
                 end
 
-                def snapshot_rollback(bootmode)
-                   vmrun("revertToSnapshot", "#{vmx_path}", snapshot_list.last)
+                def snapshot_rollback(bootmode, name)
+                   vmrun("revertToSnapshot", "#{vmx_path}", name || snapshot_list.last)
                    start
                 end
 
                 def snapshot_list
                     snapshots = []
                     vmrun("listSnapshots", "#{vmx_path}").stdout.split("\n").each do |line|
-                        if line =~ /^vagrant-snap-/
+                        if line !~ /Total snapshot/
                             snapshots << line
                         end
                     end
-                    snapshots.sort
+                    snapshots
                 end
 
                 def has_snapshot?


### PR DESCRIPTION
`vagrant snap take` and `vagrant snap rollback` now take the optional `--name` argument.

Fixes #8 
